### PR TITLE
Improve the route/ingress selection

### DIFF
--- a/deployment/templates/cloud-registry-route.yaml
+++ b/deployment/templates/cloud-registry-route.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.clusterType "openshift" }}
+{{ if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-clusterType: openshift
-
 host_name: cloud-registry.rahtiapp.fi
 
 cloud_registry:


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the route selection mechanism by using the presence of the 'route.openshift.io/v1' API version to determine the route configuration, and removes the 'clusterType' variable from the deployment values configuration.

- **Enhancements**:
    - Improved the route selection logic by checking for the presence of the 'route.openshift.io/v1' API version instead of relying on the 'clusterType' value.
- **Deployment**:
    - Removed the 'clusterType' variable from the deployment values configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->