### PR TITLE
feat: pagination in services and types

### DIFF
--- a/cloud_registry/api/20201108.e0358db.openapi.yaml
+++ b/cloud_registry/api/20201108.e0358db.openapi.yaml
@@ -223,7 +223,8 @@ components:
       required:
         - page
         - page_size
-        - total
+        - total_count
+        - total_pages
       properties:
         page:
           type: integer
@@ -233,7 +234,11 @@ components:
           type: integer
           description: "Number of entries in a page"
           example: 10
-        total:
+        total_count:
+          type: integer
+          description: "Total number of entries for the query"
+          example: 30
+        total_pages:
           type: integer
           description: "Total number of entries for the query"
           example: 30

--- a/cloud_registry/api/20201108.e0358db.openapi.yaml
+++ b/cloud_registry/api/20201108.e0358db.openapi.yaml
@@ -26,12 +26,14 @@ paths:
           required: false
           schema:
             type: integer
+            minimum: 1
             example: 1
         - name: page_size
           in: query
           required: false
           schema:
             type: integer
+            minimum: 1
             example: 10
       responses:
         '200':

--- a/cloud_registry/api/20201108.e0358db.openapi.yaml
+++ b/cloud_registry/api/20201108.e0358db.openapi.yaml
@@ -20,15 +20,30 @@ paths:
       operationId: getServices
       tags:
         - services
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            example: 1
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            example: 10
       responses:
         '200':
           description: 'List of services'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ExternalService'
+                oneOf:
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/ExternalService'
+                  - $ref: '#/components/schemas/PaginatedExternalService'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -80,9 +95,11 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ServiceType'
+                oneOf:
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/ServiceType'
+                  - $ref: '#/components/schemas/PaginatedServiceType'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -198,3 +215,41 @@ components:
       required:
         - status
         - title
+    PaginationMetadata:
+      description: 'Pagination Metadata'
+      type: object
+      required:
+        - page
+        - page_size
+        - total
+      properties:
+        page:
+          type: integer
+          description: "Current page of the response"
+          example: 1
+        page_size:
+          type: integer
+          description: "Number of entries in a page"
+          example: 10
+        total:
+          type: integer
+          description: "Total number of entries for the query"
+          example: 30
+    PaginatedExternalService:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExternalService'
+        pagination:
+          $ref: '#/components/schemas/PaginationMetadata'
+    PaginatedServiceType:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceType'
+        pagination:
+          $ref: '#/components/schemas/PaginationMetadata'

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -45,7 +45,7 @@ def getServices(**kwargs) -> List:
     total_count = db_collection_service.count_documents({})
     total_pages = floor(total_count / page_size) + (1 if total_count % page_size > 0 else 0)
 
-    if page < 1 or page > total_pages:
+    if page < 1 or (total_count > 0 and page > total_pages):
         raise BadRequest
     
     skip_items = (page - 1) * page_size
@@ -112,7 +112,7 @@ def getServiceTypes(**kwargs) -> List:
     page = page or 1
     page_size = page_size or 10
     total_count = len(uniq_types)
-    total_pages = (total_count // page_size) + (1 if total_count % page_size > 0 else 0)
+    total_pages = floor(total_count / page_size) + (1 if total_count % page_size > 0 else 0)
 
     if page < 1 or (total_count > 0 and page > total_pages):
         raise BadRequest

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -104,9 +104,17 @@ def getServiceTypes(**kwargs) -> Union[List, Dict]:
     page = request.args.get("page", type=int)
     page_size = request.args.get("page_size", type=int)
 
-    services = getServices.__wrapped__()
-    if isinstance(services, dict):
-        services = services["results"]
+    # get all the services
+    foca_conf = current_app.config.foca  # type: ignore[attr-defined]
+    db_collection_service = (
+        foca_conf.db.dbs["serviceStore"].collections["services"].client
+    )
+    services = list(
+        db_collection_service.find(
+            filter={},
+            projection={"_id": False},
+        )
+    )
     types = [s["type"] for s in services]
     uniq_types = [dict(t) for t in {tuple(sorted(d.items())) for d in types}]
 

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -2,7 +2,7 @@
 
 import logging
 from math import ceil
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from cloud_registry.exceptions import BadRequest, NotFound
 from cloud_registry.ga4gh.registry.service import RegisterService
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 # GET /services
 @log_traffic
-def getServices(**kwargs) -> List:
+def getServices(**kwargs) -> Union[List, Dict]:
     """List all services.
 
     Returns:
@@ -89,7 +89,7 @@ def getServiceById(serviceId: str, **kwargs) -> Dict:
 
 # GET /services/types
 @log_traffic
-def getServiceTypes(**kwargs) -> List:
+def getServiceTypes(**kwargs) -> Union[List, Dict]:
     """List types of services.
 
     Returns:

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -49,10 +49,14 @@ def getServices(**kwargs) -> Union[List, Dict]:
         raise BadRequest
 
     skip_items = (page - 1) * page_size
-    records = db_collection_service.find(
-        filter={},
-        projection={"_id": False},
-    ).skip(skip_items).limit(page_size)
+    records = (
+        db_collection_service.find(
+            filter={},
+            projection={"_id": False},
+        )
+        .skip(skip_items)
+        .limit(page_size)
+    )
 
     return {
         "results": list(records),
@@ -60,8 +64,8 @@ def getServices(**kwargs) -> Union[List, Dict]:
             "page": page,
             "page_size": page_size,
             "total_count": total_count,
-            "total_pages": total_pages
-        }
+            "total_pages": total_pages,
+        },
     }
 
 
@@ -120,7 +124,8 @@ def getServiceTypes(**kwargs) -> Union[List, Dict]:
         raise BadRequest
 
     skip_items = (page - 1) * page_size
-    paginated_types = uniq_types[skip_items:skip_items + page_size]
+    end = skip_items + page_size
+    paginated_types = uniq_types[skip_items:end]
 
     return {
         "results": paginated_types,
@@ -128,8 +133,8 @@ def getServiceTypes(**kwargs) -> Union[List, Dict]:
             "page": page,
             "page_size": page_size,
             "total_count": total_count,
-            "total_pages": total_pages
-        }
+            "total_pages": total_pages,
+        },
     }
 
 

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -1,13 +1,14 @@
 """Controllers for service endpoints."""
 
 import logging
+from math import floor
 from typing import Dict, List, Tuple
 
+from cloud_registry.exceptions import BadRequest, NotFound
+from cloud_registry.ga4gh.registry.service import RegisterService
+from cloud_registry.ga4gh.registry.service_info import RegisterServiceInfo
 from flask import current_app, request
 from foca.utils.logging import log_traffic
-from cloud_registry.exceptions import NotFound, BadRequest
-from cloud_registry.ga4gh.registry.service_info import RegisterServiceInfo
-from cloud_registry.ga4gh.registry.service import RegisterService
 
 logger = logging.getLogger(__name__)
 
@@ -18,18 +19,49 @@ def getServices(**kwargs) -> List:
     """List all services.
 
     Returns:
-        List of services.
+        List of services or Paginated list of services.
     """
+
+    # Get pagination data
+    page = request.args.get("page", type=int)
+    page_size = request.args.get("page_size", type=int)
+
     foca_conf = current_app.config.foca  # type: ignore[attr-defined]
     db_collection_service = (
         foca_conf.db.dbs["serviceStore"].collections["services"].client
     )
+    
+    # return list if no pagination query found
+    if page == None and page_size == None:
+        records = db_collection_service.find(
+            filter={},
+            projection={"_id": False},
+        )
+        return list(records)
+    
+    # Return paginated response
+    page = page or 1
+    page_size = page_size or 10
+    total_count = db_collection_service.count_documents({})
+    total_pages = floor(total_count / page_size) + (1 if total_count % page_size > 0 else 0)
+
+    if page < 1 or page > total_pages:
+        raise BadRequest
+    
+    skip_items = (page - 1) * page_size
     records = db_collection_service.find(
         filter={},
         projection={"_id": False},
-    )
-    return list(records)
+    ).skip(skip_items).limit(page_size)
 
+    return {
+        "results": list(records),
+        "pagination": {
+            "page": page,
+            "page_size": page_size,
+            "total": total_count,
+        }
+    }
 
 # GET /services/{serviceId}
 @log_traffic
@@ -61,12 +93,41 @@ def getServiceTypes(**kwargs) -> List:
     Returns:
         List of distinct service types.
     """
+    
+    # Get pagination data
+    page = request.args.get("page", type=int)
+    page_size = request.args.get("page_size", type=int)
+    
     services = getServices.__wrapped__()
+    if isinstance(services, dict):
+        services = services["results"]
     types = [s["type"] for s in services]
     uniq_types = [dict(t) for t in {tuple(sorted(d.items())) for d in types}]
+    
+    # return list if no pagination query found
+    if page == None and page_size == None:    
+        return uniq_types
+    
+    # return paginated response
+    page = page or 1
+    page_size = page_size or 10
+    total_count = len(uniq_types)
+    total_pages = (total_count // page_size) + (1 if total_count % page_size > 0 else 0)
 
-    return uniq_types
-
+    if page < 1 or (total_count > 0 and page > total_pages):
+        raise BadRequest
+    
+    skip_items = (page - 1) * page_size
+    paginated_types = uniq_types[skip_items : skip_items + page_size]
+    
+    return {
+        "results": paginated_types,
+        "pagination": {
+            "page": page,
+            "page_size": page_size,
+            "total": total_count,
+        }
+    }
 
 # GET /service-info
 @log_traffic

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -1,7 +1,7 @@
 """Controllers for service endpoints."""
 
 import logging
-from math import floor
+from math import ceil
 from typing import Dict, List, Tuple
 
 from cloud_registry.exceptions import BadRequest, NotFound
@@ -43,7 +43,7 @@ def getServices(**kwargs) -> List:
     page = page or 1
     page_size = page_size or 10
     total_count = db_collection_service.count_documents({})
-    total_pages = floor(total_count / page_size) + (1 if total_count % page_size > 0 else 0)
+    total_pages = ceil(total_count / page_size)
 
     if page < 1 or (total_count > 0 and page > total_pages):
         raise BadRequest
@@ -59,7 +59,8 @@ def getServices(**kwargs) -> List:
         "pagination": {
             "page": page,
             "page_size": page_size,
-            "total": total_count,
+            "total_count": total_count,
+            "total_pages": total_pages
         }
     }
 
@@ -112,7 +113,7 @@ def getServiceTypes(**kwargs) -> List:
     page = page or 1
     page_size = page_size or 10
     total_count = len(uniq_types)
-    total_pages = floor(total_count / page_size) + (1 if total_count % page_size > 0 else 0)
+    total_pages = ceil(total_count / page_size)
 
     if page < 1 or (total_count > 0 and page > total_pages):
         raise BadRequest
@@ -125,7 +126,8 @@ def getServiceTypes(**kwargs) -> List:
         "pagination": {
             "page": page,
             "page_size": page_size,
-            "total": total_count,
+            "total_count": total_count,
+            "total_pages": total_pages
         }
     }
 

--- a/cloud_registry/ga4gh/registry/server.py
+++ b/cloud_registry/ga4gh/registry/server.py
@@ -30,15 +30,15 @@ def getServices(**kwargs) -> List:
     db_collection_service = (
         foca_conf.db.dbs["serviceStore"].collections["services"].client
     )
-    
+
     # return list if no pagination query found
-    if page == None and page_size == None:
+    if page is None and page_size is None:
         records = db_collection_service.find(
             filter={},
             projection={"_id": False},
         )
         return list(records)
-    
+
     # Return paginated response
     page = page or 1
     page_size = page_size or 10
@@ -47,7 +47,7 @@ def getServices(**kwargs) -> List:
 
     if page < 1 or (total_count > 0 and page > total_pages):
         raise BadRequest
-    
+
     skip_items = (page - 1) * page_size
     records = db_collection_service.find(
         filter={},
@@ -63,6 +63,7 @@ def getServices(**kwargs) -> List:
             "total_pages": total_pages
         }
     }
+
 
 # GET /services/{serviceId}
 @log_traffic
@@ -94,21 +95,21 @@ def getServiceTypes(**kwargs) -> List:
     Returns:
         List of distinct service types.
     """
-    
+
     # Get pagination data
     page = request.args.get("page", type=int)
     page_size = request.args.get("page_size", type=int)
-    
+
     services = getServices.__wrapped__()
     if isinstance(services, dict):
         services = services["results"]
     types = [s["type"] for s in services]
     uniq_types = [dict(t) for t in {tuple(sorted(d.items())) for d in types}]
-    
+
     # return list if no pagination query found
-    if page == None and page_size == None:    
+    if page is None and page_size is None:
         return uniq_types
-    
+
     # return paginated response
     page = page or 1
     page_size = page_size or 10
@@ -117,10 +118,10 @@ def getServiceTypes(**kwargs) -> List:
 
     if page < 1 or (total_count > 0 and page > total_pages):
         raise BadRequest
-    
+
     skip_items = (page - 1) * page_size
-    paginated_types = uniq_types[skip_items : skip_items + page_size]
-    
+    paginated_types = uniq_types[skip_items:skip_items + page_size]
+
     return {
         "results": paginated_types,
         "pagination": {
@@ -130,6 +131,7 @@ def getServiceTypes(**kwargs) -> List:
             "total_pages": total_pages
         }
     }
+
 
 # GET /service-info
 @log_traffic

--- a/tests/ga4gh/registry/test_server.py
+++ b/tests/ga4gh/registry/test_server.py
@@ -55,8 +55,11 @@ def test_getServices():
         data.append(mock_resp)
 
     # check whether getServices returns the same list
-    with app.app_context():
+    with app.test_request_context("services"):
         res = getServices.__wrapped__()
+        # For paginated response extract the data present in result field
+        if "results" in res:
+            res = res["results"]
         assert res == data
 
 
@@ -111,8 +114,10 @@ def test_getServiceTypes_duplicates():
             "services"
         ].client.insert_one(mock_resp)
 
-    with app.app_context():
+    with app.test_request_context("services"):
         res = getServiceTypes.__wrapped__()
+        if "results" in res:
+            res = res["results"]
         # All written services have same type, we expect list of length 1
         assert res == [MOCK_TYPE]
 
@@ -139,8 +144,11 @@ def test_getServiceTypes_distinct():
             "services"
         ].client.insert_one(mock_resp)
 
-    with app.app_context():
+    with app.test_request_context("services"):
         res = getServiceTypes.__wrapped__()
+        # For paginated response extract the data present in result field
+        if "results" in res:
+            res = res["results"]
         # All written services have distinct types, we expect a list of the
         # same length as there are entries in the database collection
         assert len(res) == len(services)


### PR DESCRIPTION
## Description

Adds backward compatible pagination to the `services` and `service/types` endpoint.

Fixes #58 (issue)

## Type of change
New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [ ] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

## Summary by Sourcery

Add optional pagination support to the services and service types endpoints while preserving the existing non-paginated behaviour.

New Features:
- Introduce query-based pagination for the /services endpoint returning paginated service lists when page parameters are supplied.
- Introduce query-based pagination for the /service/types endpoint returning paginated service type lists when page parameters are supplied.

Enhancements:
- Extend the OpenAPI specification to describe optional pagination query parameters and paginated response schemas for services and service types.